### PR TITLE
Migrate original Ty extension into zed-extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ty"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+path = "src/tychecker.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+zed_extension_api = "^0.2.0"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# ty-zed: `astral-sh/ty` for Zed
+
+This extension provides [`ty`](https://github.com/astral-sh/ty), an extremely fast Python type checker and language server, for Zed editor.
+
+## Installation
+Open Zed extensions page, and search `ty` to install.
+
+## Enable
+Enable `ty` in your settings.
+
+```jsonc
+{
+  "languages": {
+    "Python": {
+      "language_servers": ["ty"]
+  },
+}
+```
+
+## Configure
+
+Configure under `lsp.ty.settings` as required. The "binary" setting must be filled in.
+
+```jsonc
+{
+  "lsp": {
+    "ty": {
+      "binary": {
+        "path": "/Users/yourname/.local/bin/ty",
+        "arguments": ["server"]
+      }
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ty-zed: `astral-sh/ty` for Zed
+# ty: `astral-sh/ty` for Zed
 
 This extension provides [`ty`](https://github.com/astral-sh/ty), an extremely fast Python type checker and language server, for Zed editor.
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,0 +1,12 @@
+id = "ty"
+name = "Ty"
+description = "An extremely fast Python type checker and language server, written in Rust."
+version = "0.0.1"
+schema_version = 1
+authors = ["Mrzz <runze.ma@outlook.com>"]
+repository = "https://github.com/astral-sh/ty"
+
+
+[language_servers.ty]
+name = "Ty"
+languages = ["Python"]

--- a/src/tychecker.rs
+++ b/src/tychecker.rs
@@ -1,0 +1,53 @@
+use zed_extension_api::{self as zed, settings::LspSettings};
+
+struct TyExtension;
+
+impl zed::Extension for TyExtension {
+    fn new() -> Self {
+        Self {}
+    }
+
+    fn language_server_command(
+        &mut self,
+        _language_server_id: &zed_extension_api::LanguageServerId,
+        worktree: &zed_extension_api::Worktree,
+    ) -> zed_extension_api::Result<zed_extension_api::Command> {
+        let binary_path = LspSettings::for_worktree("ty", worktree)
+            .ok()
+            .and_then(|s| s.binary)
+            .and_then(|b| b.path)
+            .ok_or("Ty binary path not found in configuration")?;
+        Ok(zed::Command {
+            // Ok uses zed::Command
+            command: binary_path,
+            args: vec!["server".into()],
+            env: vec![],
+        })
+    }
+
+    fn language_server_initialization_options(
+        &mut self,
+        server_id: &zed_extension_api::LanguageServerId,
+        worktree: &zed_extension_api::Worktree,
+    ) -> zed_extension_api::Result<Option<zed_extension_api::serde_json::Value>> {
+        let settings = LspSettings::for_worktree(server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.initialization_options.clone())
+            .unwrap_or_default();
+        Ok(Some(settings))
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        server_id: &zed_extension_api::LanguageServerId,
+        worktree: &zed_extension_api::Worktree,
+    ) -> zed_extension_api::Result<Option<zed_extension_api::serde_json::Value>> {
+        let settings = LspSettings::for_worktree(server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .unwrap_or_default();
+        Ok(Some(settings))
+    }
+}
+
+zed::register_extension!(TyExtension);


### PR DESCRIPTION
This PR migrates the original Ty extension (https://github.com/mrzzmrzz/ty-zed) to the `zed-extensions` organization.

Let me know if any adjustments are needed!